### PR TITLE
fix: Invalid hook call

### DIFF
--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -46,8 +46,6 @@ const ThemeToggle = () => {
     applyTheme(theme)
   }, [theme, mounted, controlsSun, controlsMoon, controlsSystem])
 
-  if (!mounted) return null
-
   const applyTheme = (newTheme: string) => {
     const root = document.documentElement
 

--- a/src/content/posts/Get-start.md
+++ b/src/content/posts/Get-start.md
@@ -49,17 +49,6 @@ pnpm install
 pnpm dev
 ```
 
-> [!note]
-> When you first start the project, you might see this React-related warning:
-> ```text
-> Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
-> 1. You might have mismatching versions of React and the renderer (such as React DOM)
-> 2. You might be breaking the Rules of Hooks
-> 3. You might have more than one copy of React in the same app
-> See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.
-> ```
-> This warning is caused by the interaction between React plugin and MDX plugin. According to Astro's official statement, this warning can be safely ignored.
-
 ## Project Configuration
 
 Before customizing your site, familiarize yourself with the [project structure](/posts/project-structure). There are three main configuration areas to focus on:


### PR DESCRIPTION
Resolves the following warning when running `pnpm dev`

```
Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://react.dev/link/invalid-hook-call for tips about how to debug and fix this problem.
```

Documentation: https://react.dev/warnings/invalid-hook-call-warning