### PR TITLE
fix: restore header glow visibility and prevent it from being covered…

### DIFF
--- a/src/components/base/SkillsShowcase.astro
+++ b/src/components/base/SkillsShowcase.astro
@@ -11,7 +11,7 @@ const { skillsData }: Props = Astro.props
 const duplicateSkills = (skills: Skill[]) => [...skills, ...skills, ...skills, ...skills]
 ---
 
-<div class="skills-container relative py-2 px-2 max-md:px-0 perspective-[1500px]">
+<div class="skills-container relative py-2 px-2 max-md:px-0 perspective-[1500px] [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
   {
     skillsData.map((row: SkillData) => {
       const duplicatedSkills = duplicateSkills(row.skills)
@@ -45,9 +45,6 @@ const duplicateSkills = (skills: Skill[]) => [...skills, ...skills, ...skills, .
       )
     })
   }
-
-  <div class="pointer-events-none absolute left-0 top-0 w-[10%] h-full bg-gradient-to-r from-background to-transparent z-10"></div>
-  <div class="pointer-events-none absolute right-0 top-0 w-[10%] h-full bg-gradient-to-l from-background to-transparent z-10"></div>
 </div>
 
 <style is:global>

--- a/src/components/theme/HeaderGradient.astro
+++ b/src/components/theme/HeaderGradient.astro
@@ -3,10 +3,10 @@ import { cn } from '~/lib/utils'
 ---
 
 <div class={cn('fixed inset-0 mx-0 max-w-none hidden overflow-hidden md:block pointer-events-none dark:opacity-100')}>
-  <div class="absolute left-1/2 top-[-14.5px] ml-[-41.5rem] h-[25rem] w-[80rem]">
+  <div class="absolute left-1/2 top-[-14.5px] ml-[-41.5rem] h-[25rem] w-[80rem] dark:[mask-image:linear-gradient(white,transparent)]">
     <!-- Blue glow -->
     <div
-      class="absolute inset-0 z-[2] bg-gradient-to-r from-blue-400/25 to-blue-800/25 opacity-40 [mask-image:radial-gradient(farthest-side_at_top,white,transparent)] dark:from-blue-500/30 dark:to-blue-800/30 dark:opacity-100"
+      class="absolute inset-0 bg-gradient-to-r from-blue-400/25 to-blue-800/25 opacity-40 [mask-image:radial-gradient(farthest-side_at_top,white,transparent)] dark:from-blue-500/30 dark:to-blue-800/30 dark:opacity-100"
     >
     </div>
 
@@ -14,7 +14,7 @@ import { cn } from '~/lib/utils'
     <svg
       viewBox="0 0 1113 440"
       aria-hidden="true"
-      class="absolute left-1/2 top-0 z-0 ml-[-19rem] w-[69.5625rem] fill-background dark:fill-zinc-950 blur-[26px]"
+      class="absolute left-1/2 top-0 ml-[-19rem] w-[69.5625rem] fill-background dark:fill-zinc-950 blur-[26px]"
     >
       <path d="M.016 439.5s-9.5-300 434-300S882.516 20 882.516 20V0h230.004v439.5H.016Z"></path>
     </svg>


### PR DESCRIPTION
… by skill shadows

Revert HeaderGradient to its original layered structure so the blue halo renders visibly and the irregular SVG only masks the glow instead of occluding page text. Replace the opaque side shadows in SkillsShowcase with a mask-image fade so the glow no longer gets hidden beneath them.